### PR TITLE
zig update: replace inline with callconv(.Inline)

### DIFF
--- a/src/crypto.zig
+++ b/src/crypto.zig
@@ -38,7 +38,7 @@ pub const ChaCha20Stream = struct {
         };
     }
 
-    inline fn chacha20Core(x: *BlockVec, input: BlockVec) void {
+    fn chacha20Core(x: *BlockVec, input: BlockVec) callconv(.Inline) void {
         x.* = input;
 
         const rounds = comptime [_]QuarterRound{
@@ -67,7 +67,7 @@ pub const ChaCha20Stream = struct {
         }
     }
 
-    inline fn hashToBytes(out: *[64]u8, x: BlockVec) void {
+    fn hashToBytes(out: *[64]u8, x: BlockVec) callconv(.Inline) void {
         var i: usize = 0;
         while (i < 4) : (i += 1) {
             mem.writeIntLittle(u32, out[16 * i + 0 ..][0..4], x[i * 4 + 0]);
@@ -77,7 +77,7 @@ pub const ChaCha20Stream = struct {
         }
     }
 
-    inline fn contextFeedback(x: *BlockVec, ctx: BlockVec) void {
+    fn contextFeedback(x: *BlockVec, ctx: BlockVec) callconv(.Inline) void {
         var i: usize = 0;
         while (i < 16) : (i += 1) {
             x[i] +%= ctx[i];
@@ -396,10 +396,10 @@ pub const ecc = struct {
         P.* = Q;
     }
 
-    inline fn point_double(comptime Curve: type, P: *Jacobian(Curve)) void {
+    fn point_double(comptime Curve: type, P: *Jacobian(Curve)) callconv(.Inline) void {
         _ = run_code(Curve, P, P.*, &code.double);
     }
-    inline fn point_add(comptime Curve: type, P1: *Jacobian(Curve), P2: Jacobian(Curve)) void {
+    fn point_add(comptime Curve: type, P1: *Jacobian(Curve), P2: Jacobian(Curve)) callconv(.Inline) void {
         _ = run_code(Curve, P1, P2, &code._add);
     }
 
@@ -669,39 +669,39 @@ pub const ecc = struct {
         return result;
     }
 
-    inline fn MUL31(x: u32, y: u32) u64 {
+    fn MUL31(x: u32, y: u32) callconv(.Inline) u64 {
         return @as(u64, x) * @as(u64, y);
     }
 
-    inline fn MUL31_lo(x: u32, y: u32) u32 {
+    fn MUL31_lo(x: u32, y: u32) callconv(.Inline) u32 {
         return (x *% y) & 0x7FFFFFFF;
     }
 
-    inline fn MUX(ctl: u32, x: u32, y: u32) u32 {
+    fn MUX(ctl: u32, x: u32, y: u32) callconv(.Inline) u32 {
         return y ^ (@bitCast(u32, -@bitCast(i32, ctl)) & (x ^ y));
     }
-    inline fn NOT(ctl: u32) u32 {
+    fn NOT(ctl: u32) callconv(.Inline) u32 {
         return ctl ^ 1;
     }
-    inline fn NEQ(x: u32, y: u32) u32 {
+    fn NEQ(x: u32, y: u32) callconv(.Inline) u32 {
         const q = x ^ y;
         return (q | @bitCast(u32, -@bitCast(i32, q))) >> 31;
     }
-    inline fn EQ(x: u32, y: u32) u32 {
+    fn EQ(x: u32, y: u32) callconv(.Inline) u32 {
         const q = x ^ y;
         return NOT((q | @bitCast(u32, -@bitCast(i32, q))) >> 31);
     }
-    inline fn CMP(x: u32, y: u32) i32 {
+    fn CMP(x: u32, y: u32) callconv(.Inline) i32 {
         return @bitCast(i32, GT(x, y)) | -@bitCast(i32, GT(y, x));
     }
-    inline fn GT(x: u32, y: u32) u32 {
+    fn GT(x: u32, y: u32) callconv(.Inline) u32 {
         const z = y -% x;
         return (z ^ ((x ^ y) & (x ^ z))) >> 31;
     }
-    inline fn LT(x: u32, y: u32) u32 {
+    fn LT(x: u32, y: u32) callconv(.Inline) u32 {
         return GT(y, x);
     }
-    inline fn GE(x: u32, y: u32) u32 {
+    fn GE(x: u32, y: u32) callconv(.Inline) u32 {
         return NOT(GT(y, x));
     }
 
@@ -714,7 +714,7 @@ pub const ecc = struct {
     // @TODO Remove lots of len and Curve parameters, just use the first byte calcualtions
     // This will make all these functions shared for and reduce code bloat
 
-    inline fn set_zero(comptime len: usize, out: *[len]u32, bit_len: u32) void {
+    fn set_zero(comptime len: usize, out: *[len]u32, bit_len: u32) callconv(.Inline) void {
         out[0] = bit_len;
         mem.set(u32, out[1..][0 .. (bit_len + 31) >> 5], 0);
     }
@@ -743,7 +743,7 @@ pub const ecc = struct {
         return q;
     }
 
-    inline fn div(hi: u32, lo: u32, d: u32) u32 {
+    fn div(hi: u32, lo: u32, d: u32) callconv(.Inline) u32 {
         var r: u32 = undefined;
         return divrem(hi, lo, d, &r);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -842,7 +842,7 @@ pub const curves = struct {
         const pub_key_len = 32;
         const Keys = std.crypto.dh.X25519.KeyPair;
 
-        inline fn make_key_pair(rand: *std.rand.Random) Keys {
+        fn make_key_pair(rand: *std.rand.Random) callconv(.Inline) Keys {
             while (true) {
                 var seed: [32]u8 = undefined;
                 rand.bytes(&seed);
@@ -850,11 +850,11 @@ pub const curves = struct {
             } else unreachable;
         }
 
-        inline fn make_pre_master_secret(
+        fn make_pre_master_secret(
             key_pair: Keys,
             pre_master_secret_buf: []u8,
             server_public_key: *const [32]u8,
-        ) ![]const u8 {
+        ) callconv(.Inline) ![]const u8 {
             pre_master_secret_buf[0..32].* = std.crypto.dh.X25519.scalarmult(
                 key_pair.secret_key,
                 server_public_key.*,
@@ -869,17 +869,17 @@ pub const curves = struct {
         const pub_key_len = 97;
         const Keys = crypto.ecc.KeyPair(crypto.ecc.SECP384R1);
 
-        inline fn make_key_pair(rand: *std.rand.Random) Keys {
+        fn make_key_pair(rand: *std.rand.Random) callconv(.Inline) Keys {
             var seed: [48]u8 = undefined;
             rand.bytes(&seed);
             return crypto.ecc.make_key_pair(crypto.ecc.SECP384R1, seed);
         }
 
-        inline fn make_pre_master_secret(
+        fn make_pre_master_secret(
             key_pair: Keys,
             pre_master_secret_buf: []u8,
             server_public_key: *const [97]u8,
-        ) ![]const u8 {
+        ) callconv(.Inline) ![]const u8 {
             pre_master_secret_buf[0..96].* = crypto.ecc.scalarmult(
                 crypto.ecc.SECP384R1,
                 server_public_key[1..].*,
@@ -895,17 +895,17 @@ pub const curves = struct {
         const pub_key_len = 65;
         const Keys = crypto.ecc.KeyPair(crypto.ecc.SECP256R1);
 
-        inline fn make_key_pair(rand: *std.rand.Random) Keys {
+        fn make_key_pair(rand: *std.rand.Random) callconv(.Inline) Keys {
             var seed: [32]u8 = undefined;
             rand.bytes(&seed);
             return crypto.ecc.make_key_pair(crypto.ecc.SECP256R1, seed);
         }
 
-        inline fn make_pre_master_secret(
+        fn make_pre_master_secret(
             key_pair: Keys,
             pre_master_secret_buf: []u8,
             server_public_key: *const [65]u8,
-        ) ![]const u8 {
+        ) callconv(.Inline) ![]const u8 {
             pre_master_secret_buf[0..64].* = crypto.ecc.scalarmult(
                 crypto.ecc.SECP256R1,
                 server_public_key[1..].*,
@@ -955,7 +955,7 @@ pub const curves = struct {
         });
     }
 
-    inline fn make_key_pair(comptime list: anytype, curve_id: u16, rand: *std.rand.Random) KeyPair(list) {
+    fn make_key_pair(comptime list: anytype, curve_id: u16, rand: *std.rand.Random) callconv(.Inline) KeyPair(list) {
         inline for (list) |curve| {
             if (curve.tag == curve_id) {
                 return @unionInit(KeyPair(list), curve.name, curve.make_key_pair(rand));
@@ -964,13 +964,13 @@ pub const curves = struct {
         unreachable;
     }
 
-    inline fn make_pre_master_secret(
+    fn make_pre_master_secret(
         comptime list: anytype,
         curve_id: u16,
         key_pair: KeyPair(list),
         pre_master_secret_buf: *[max_pre_master_secret_len(list)]u8,
         server_public_key: [max_pub_key_len(list)]u8,
-    ) ![]const u8 {
+    ) callconv(.Inline) ![]const u8 {
         inline for (list) |curve| {
             if (curve.tag == curve_id) {
                 return try curve.make_pre_master_secret(
@@ -1453,11 +1453,11 @@ pub fn client_connect(
         };
 
         const next_32_bytes = struct {
-            inline fn f(
+            fn f(
                 state: *KeyExpansionState,
                 comptime chunk_idx: comptime_int,
                 chunk: *[32]u8,
-            ) void {
+            ) callconv(.Inline) void {
                 if (chunk_idx == 0) {
                     Hmac256.create(state.a1[0..32], state.seed, state.master_secret);
                     Hmac256.create(chunk, state.a1, state.master_secret);


### PR DESCRIPTION
get iguanaTLS building again after https://github.com/ziglang/zig/pull/7749